### PR TITLE
Added custom imprint and privacy statement

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -11,8 +11,8 @@
           <li><a href="{{ site.github.repository_url }}/issues"><i class="fa fa-ticket"></i> Issues</a></li>
           <li><a href="{{ site.github.repository_url }}/fork"><i class="fa fa-code-fork"></i> Fork us!</a></li>
           {% endif %}
-          <li><a href="https://www.opitz-consulting.com/impressum.html">Impressum</a></li>
-          <li><a href="https://www.opitz-consulting.com/datenschutz.html">Datenschutz</a></li>
+          <li><a href="{{ site.baseurl }}/imprint.html">Impressum / Imprint</a></li>
+          <li><a href="{{ site.baseurl }}/privacy-statement.html">Privacy Statement</a></li>
         </ul>
       </div>
 

--- a/imprint.md
+++ b/imprint.md
@@ -1,0 +1,43 @@
+---
+layout: index
+---
+Notice: To be in accordance with German law, we must publish an Imprint.
+Therefore, the imprint is presented in German
+
+# Impressum
+
+## Angaben gemäß §5 TMG:
+
+Richard Attermeyer\\
+Debbingstraße 9\\
+46286 Dorsten\\
+
+## Kontakt
+Telefon: +49 173 727 9004\\
+Email: richard.attermeyer At @ gmail Punkt com
+
+Der Nutzung von im Rahmen der Impressumspflicht veröffentlichten Kontaktdaten durch Dritte zur Übersendung von nicht ausdrücklich angeforderter Werbung und Informationsmaterialien wird hiermit ausdrücklich widersprochen. Ich behalte mir ausdrücklich rechtliche Schritte im Falle der unverlangten Zusendung von Werbeinformationen etwa durch Spam-Emails oder Postsendungen vor.
+
+## Haftung für Inhalte
+Als Diensteanbieter sind wir gemäß § 7 Abs.1 TMG für eigene Inhalte auf diesen Seiten nach den
+allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 TMG sind wir als Diensteanbieter jedoch nicht
+verpflichtet, übermittelte oder gespeicherte fremde Informationen zu überwachen oder nach Umständen zu
+forschen, die auf eine rechtswidrige Tätigkeit hinweisen.
+Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen
+Gesetzen bleiben hiervon unberührt. Eine diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der
+Kenntnis einer konkreten Rechtsverletzung möglich. Bei Bekanntwerden von entsprechenden
+Rechtsverletzungen werden wir diese Inhalte umgehend entfernen.
+
+Wir übernehmen keine Gewähr für Aktualität, Korrektheit, Vollständigkeit oder Qualität der bereitgestellten Informationen. Haftungsansprüche, die sich auf Schäden materieller oder ideeller Art beziehen, die durch die Nutzung oder Nichtnutzung der dargebotenen Informationen, bzw. durch die Nutzung fehlerhafter und unvollständiger Informationen verursacht wurden, sind grundsätzlich ausgeschlossen.
+
+Alle Angebote sind freibleibend und unverbindlich. Ich behalte es mir ausdrücklich vor, Teile der Webseite oder das gesamte Angebot ohne gesonderte Ankündigung zu verändern, zu ergänzen, zu löschen oder die Veröffentlichung zeitweise oder endgültig einzustellen.
+
+## Haftung für Links
+
+Unsere Seiten enthalten Verlinkungen zu externen Websites Dritter, auf deren Inhalte wir keinen Einfluss haben.
+Für diese fremden Inhalte können wir daher auch keine Gewähr übernehmen. Für die Inhalte der
+verlinkten Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten verantwortlich. Die verlinkten
+Seiten wurden zum Zeitpunkt der Verlinkung auf mögliche Rechtsverstöße überprüft. Rechtswidrige Inhalte
+waren zum Zeitpunkt der Verlinkung nicht erkennbar.
+Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist jedoch ohne konkrete Anhaltspunkte einer
+Rechtsverletzung nicht zumutbar. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Links umgehend entfernen

--- a/privacy-statement.md
+++ b/privacy-statement.md
@@ -1,0 +1,93 @@
+---
+layout: index
+---
+
+# Privacy Statement
+
+This privacy statement explains to you the type, scope and purpose of the processing of personal data (hereinafter referred to as "data") as part of the provision of our services and within our online offer and the websites, functions and contents connected with it as well as external online presences, e.g. our social media profile (hereinafter jointly referred to as "online offer"). With regard to the terms used, such as "processing" or "person responsible", we refer to the definitions in Art. 4 of the EU [General Data Protection Regulation](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=celex%3A32016R0679) (GDPR).
+
+## Person in charge
+
+Richard Attermeyer\\
+Debbingstraße 9\\
+46286 Dorsten\\
+Germany\\
+Email: richard.attermeyer At @ gmail Punkt com
+
+
+## Types of data processed
+
+- Inventory data (for example, personal master data, names or addresses).
+- Contact details (e.g., e-mail, telephone numbers).
+- Content data (e.g., text input, photographs, videos).
+- Usage data (e.g., visited websites, interest in content, access times).
+- Meta/communication data (e.g., device information, IP addresses).
+
+## Categories of persons concerned
+
+Visitors and users of the online offer (hereinafter referred to as "users").
+
+## Purpose of processing
+
+- Provision of the online offer, its functions and contents.
+- Response to contact requests and communication with users.
+- Security measures.
+- Range measurement/marketing
+
+## Terms used
+
+"Personal data" means any information relating to an identified or identifiable natural person (hereinafter referred to as "data subject"); an identifiable natural person is one who can be identified, directly or indirectly, in particular by assignment to an identifier such as a name, an identification number, location data, an online identifier (e.g. cookie) or to one or more special features that express the physical, physiological, genetic, psychological, economic, cultural or social identity of that natural person.
+
+"processing" means any operation or series of operations carried out with or without the aid of automated procedures in connection with personal data. The term goes a long way and covers practically every handling of data.
+
+"pseudonymisation" means the processing of personal data in such a way that the personal data can no longer be attributed to a specific data subject without the use of additional information, provided that this additional information is kept separately and is subject to technical and organisational measures to ensure that the personal data are not attributed to an identified or identifiable natural person.
+
+"Profiling" means any automated processing of personal data consisting in the use of such personal data to evaluate certain personal aspects relating to a natural person, in particular to analyse or predict aspects relating to the work performance, economic situation, health, personal preferences, interests, reliability, behaviour, location or relocation of that natural person.
+
+Responsible" means the natural or legal person, authority, institution or other body that alone or together with others decides on the purposes and means of processing personal data.
+
+"processor" means a natural or legal person, authority, institution or other body processing personal data on behalf of the controller.
+Applicable legal bases
+
+## Hosting and GitHub
+The hosting services we use serve to provide the following services: Infrastructure and platform services, computing capacity, storage space and database services, e-mail delivery, security services and technical maintenance services that we use for the purpose of operating this online offer.
+
+We or our hosting provider process inventory data, contact data, content data, contract data, usage data, meta- and communication data of customers, interested parties and visitors of this online offer on the basis of our legitimate interests in an efficient and secure provision of this online offer according to Art. 6 Para. 1 lit. f GDPR in conjunction with. Art. 28 GDPR (conclusion of order processing contract).
+
+We, or our hosting provider, collect the following data on the basis of our legitimate interests within the meaning of Art. 6 para. 1 lit. f. GDPR data on each access to the server on which this service is located (so-called server log files). Access data includes the visitor’s browser type, language preference, referring site, additional websites requested, and the date and time of each visitor request. We also collect potentially personally-identifying information like Internet Protocol (IP) addresses.
+
+This web site and the code repository are hosted on GitHub ([Github]( Github Inc., 88 Colin P Kelly Jr St, San Francisco, CA 94107, USA gehostet) Inc., 88 Colin P Kelly Jr St, San Francisco, CA 94107, USA) servers.
+To the extend required to provide the code and web site hosting services, GitHub collects basic information from visitors to their  website. GitHub complies with both the EU-US Privacy Shield Framework and the General Data Protection Regulation.
+Pleare read also GitHub's [privacy statement](https://help.github.com/articles/github-privacy-statement/).
+
+## Google Analytics
+
+On the basis of our legitimate interests (i.e. interest in the analysis, optimisation and economic operation of our online offer within the meaning of Art. 6 para. 1 lit. f. GDPR) Google Analytics, a web analysis service of Google LLC ("Google"). Google uses cookies. The information generated by the cookie about the use of the online offer by users is generally transferred to a Google server in the USA and stored there.
+
+Google is certified under the Privacy Shield Agreement and thus offers a guarantee to comply with European [data protection law](https://www.privacyshield.gov/participant?id=a2zt000000001L5AAI&status=Active).
+
+Google will use this information on our behalf to evaluate the use of our online offer by users, to compile reports on the activities within this online offer and to provide us with further services associated with the use of this online offer and the use of the Internet. Pseudonymous user profiles can be created from the processed data.
+
+We use Google Analytics only with IP anonymization enabled. This means that Google will reduce the IP address of users within Member States of the European Union or in other states party to the Agreement on the European Economic Area. Only in exceptional cases will the full IP address be transmitted to a Google server in the USA and shortened there.
+
+The IP address transmitted by the user's browser is not merged with other Google data. Users can prevent the storage of cookies by setting their browser software accordingly; users can also prevent Google from collecting the data generated by the cookie and relating to their use of the online offer and the processing of this data by Google by downloading and installing the browser plug-in available under the following [link](http://tools.google.com/dlpage/gaoptout?hl=en).
+
+Further information on data use by Google, possible settings and objections can be found in [Google's data protection declaration](https://policies.google.com/technologies/ads) and in the [settings](https://adssettings.google.com/authenticated) for the display of advertisements by Google.
+
+Users' personal data will be deleted or made anonymous after 14 months.
+
+## Integration of third-party services and content
+
+Within our online offer, we make no representations or warranties of any kind based on our legitimate interests (i.e. interest in the analysis, optimisation and economic operation of our online offer within the meaning of Art. 6 para. 1 lit. f. GDPR) content or service offerings of third parties to incorporate their content and services, such as videos or fonts (hereinafter uniformly referred to as "content").
+
+This always presupposes that the third party providers of this content perceive the IP address of the users, since without the IP address they could not send the content to their browser. The IP address is therefore required for the display of this content. We make every effort to use only those contents whose respective providers use the IP address only for the delivery of the contents. Third-party providers may also use so-called pixel tags (invisible graphics, also known as "web beacons") for statistical or marketing purposes. Pixel tags" can be used to evaluate information such as visitor traffic on the pages of this website. The pseudonymous information may also be stored in cookies on the user's device and may include technical information about the browser and operating system, referring websites, visiting time and other information about the use of our online offer, as well as be linked to such information from other sources.
+
+### YouTube
+
+We integrate the videos of the platform "YouTube" of the provider Google LLC, 1600 Amphitheatre Parkway, Mountain View, CA 94043, USA. For details see their [Privacy Policy]( https://www.google.com/policies/privacy/) and [Opt-Out]( https://adssettings.google.com/authenticated).
+
+### Google Fonts
+
+We integrate the fonts ("Google Fonts") of the provider Google LLC, 1600 Amphitheatre Parkway, Mountain View, CA 94043, USA. For details see their [Privacy Policy]( https://www.google.com/policies/privacy/) and [Opt-Out]( https://adssettings.google.com/authenticated).
+
+Based on texts produced with [Datenschutz-Generator.de von RA Dr. Thomas Schwenke](https://datenschutz-generator.de/)


### PR DESCRIPTION
We have different options for the Imprint and Privacy Statement

1. Use a legal entity and name a responsible person (which should be one
of the commiters)
2. Make one of the commiters the responsible person (without any
connection to a legal entity)

I would vote for the second option, so we do not associate this with any
legal entity and have to deal with their legal department.