### PR TITLE
Write development and update guide

### DIFF
--- a/doc/development-guide.md
+++ b/doc/development-guide.md
@@ -1,0 +1,97 @@
+# Development Guide
+
+Learn all about how to make changes to OpenDevStack in your organisation and how
+to contribute those changes back upstream.
+
+For the rest of this guide, it is assumed that you have completed the
+[Getting Started](https://github.com/opendevstack) guide. In the examples, we
+will use "ACME" as the organisation name, which you will need to replace where
+required.
+
+## How to make changes to OpenDevStack
+
+Say you have encountered a bug, or want to develop a new feature. The first
+step is to implement the changes, and then try them out in your OpenDevStack
+instance. Those changes can then be contributed back (as described in the next
+section), or, if they are specific to your organisation, live on only in your
+instance.
+
+To start, clone the repository where you want to make changes from your
+BitBucket instance. The resulting repository will have its remote `origin` set
+to BitBucket.
+
+Next, you need to create a new branch where changes can be made. This branch
+must be based on a clean state. This can either be the `master` branch (if you
+are tracking bleeding edge) or, more typically, a release branch (such as
+`1.0.x`). Which one to use depends entirely on your organisation: it must be the
+branch on which the `production` branch in BitBucket is based on. For example,
+if your OpenDevStack instance is based on `1.0.x`, then you can create a new
+branch like this:
+
+```sh
+# Ensure you have the latest refs
+git fetch
+# Create a branch based on 1.0.x
+git checkout --no-track -b fix-typo origin/1.0.x
+```
+
+Once you have committed the desired changes, push your branch to BitBucket:
+```sh
+git push origin fix-typo
+```
+
+Afterwards, open a pull request. It is important that the target of the pull
+request is the `production` branch. That way, you do not pollute your base
+branch (`1.0.x`) with changes. The `production` branch exists only in your
+BitBucket instance, and it is the branch that e.g. OpenShift points to, and
+consequently is the branch where all your changes should end up in.
+
+When your changes have been tested and approved, you can merge the pull
+request in BitBucket. At this stage, you are ready to push your work upstream as
+well - continue with the next section if you want to do this.
+
+
+## How to contribute changes upstream
+
+As your base branch is never polluted with local changes, every branch created
+from it is guaranteed to not contain any local changes, or changes to your
+OpenDevStack instance that you do not want to share publicly.
+
+To contribute your work, first you need to have a space in GitHub where you have
+permissions to push your changes to. Typically, this is a fork of the repository
+owned by `github.com/opendevstack`, located at the GitHub account of your
+organisation (e.g. `github.com/acme`). If this fork does not exist yet, create
+it on GitHub using the fork feature.
+
+Next, you will need to push your branch to that repository fork. Before you are
+able to do that, you need to add the fork as a new remote to your repository:
+
+```sh
+git remote add acme https://github.com/acme/<REPO_NAME>.git
+```
+
+After that, you can push your changes there:
+```sh
+git push acme fix-typo
+```
+
+Once pushed, GitHub suggests to open a pull request, and automatically sets the
+`master` branch of the repository owned by OpenDevStack as a target. This is
+usually what you want, but there might be cases where your fix is relevant only to a
+certain release branch of OpenDevStack, in which case you need to change the
+target to that branch. Note that if you have implemented a feature, it always
+has to target `master`. That means that if you did not base your branch on
+latest master originally, and your pull request shows a merge conflict, you
+need to cherry-pick (and adapt) your changes to a branch based on latest master
+in order to have it merged.
+
+In general, to get your changes approved by core members of OpenDevStack, please
+ensure the following:
+
+* Before you make a bigger change, open a ticket first and discuss what you want
+  to do before you actually do it.
+* Explain why this change is necessary / benefitial.
+* Ensure to follow the guide above - branches containing unrelated commits or
+  features targeting release branches etc. will not be approved.
+* Adhere to the relevant coding standard as set out in each repository.
+* Add a changelog entry, linking to your pull request.

--- a/doc/development-guide.md
+++ b/doc/development-guide.md
@@ -11,8 +11,7 @@ you will need to replace appropriately.
 Say you have encountered a bug, or want to develop a new feature. The first
 step is to implement the changes, and then try them out in your OpenDevStack
 instance. Those changes can then be contributed back (as described in the next
-section), or, if they are specific to your organisation, live on only in your
-instance.
+section) unless they are specific to your organisation.
 
 To start, clone the repository where you want to make changes from your
 BitBucket instance. The resulting repository will have its remote `origin` set

--- a/doc/development-guide.md
+++ b/doc/development-guide.md
@@ -3,10 +3,8 @@
 Learn all about how to make changes to OpenDevStack in your organisation and how
 to contribute those changes back upstream.
 
-For the rest of this guide, it is assumed that you have completed the
-[Getting Started](https://github.com/opendevstack) guide. In the examples, we
-will use "ACME" as the organisation name, which you will need to replace where
-required.
+For the rest of this guide, we will use "ACME" as the organisation name, which
+you will need to replace appropriately.
 
 ## How to make changes to OpenDevStack
 

--- a/doc/update-guide.md
+++ b/doc/update-guide.md
@@ -1,0 +1,124 @@
+# Update Guide
+
+Learn all about how to update your OpenDevStack repositories and the running
+installation of it.
+
+For the rest of this guide, it is assumed that you have completed the
+[Getting Started](https://github.com/opendevstack) guide. In the examples, we
+will use "ACME" as the organisation name, which you will need to replace where
+required.
+
+## How to update your OpenDevStack repositories
+
+Updating repositories means that new refs from repositories under
+`github.com/opendevstack` are pushed into the repositories in your BitBucket
+instance. Note that only updates to the `production` branch in BitBucket will
+have any effect on the OpenDevstack installation.
+
+First, you need a clone of each repository in BitBucket which should be updated
+on your local machine.
+
+Once this has been done, you need to fetch new refs from
+`github.com/opendevstack`. To do so, add a remote pointing to it like this:
+
+```sh
+git remote add ods https://github.com/opendevstack/<REPO_NAME>.git
+```
+
+Now you are ready to update the refs. It is recommended to update both the
+`master` branch and, unless you want to live off the bleeding edge, a release
+branch such as `1.0.x`. Both is shown below:
+
+```sh
+# Ensure you have the latest refs from ODS locally
+git fetch ods
+# Update master
+git checkout master
+git reset -hard ods/master
+git push origin master
+# Update 1.0.x
+git checkout 1.0.x
+git reset -hard ods/1.0.x
+git push origin 1.0.x
+```
+
+So far, your OpenDevStack installation has not been affected yet because the
+`production` branch has not been updated yet. To do that, it is recommended to
+create a pull request on BitBucket from `master` into `production` This serves
+as a gate to control changes coming in, and spread knowledge about what has
+changed exactly.
+
+Now that changes are "live", you need update (parts of) the installation as
+described in the next section.
+
+
+## How to update your OpenDevStack installation
+
+Updating consists of two parts: following the general update procedure
+(applicable to all version updates) and a version specific update procedure.
+
+
+### General update procedure
+
+Before proceeding, it is advisable to make a backup of the existing OpenShift
+configuration. This can be done easily with Tailor:
+
+```sh
+tailor export -n cd > backup.yml
+```
+
+Note that the executing user needs to have permissions to access all resources
+in the `cd` namespaces for this to work properly.
+
+Next, update Tailor to the version corresponding to your new OpenDevStack
+version.
+
+Then, update the configuration parameters (located in `ods-configuration`)
+according to what has changedd in the `ods-configuration-sample` repository.
+
+Once configuration is up-to-date, the OpenShift templates stored within
+OpenShift need to be updated:
+
+```sh
+cd ods-project-quickstarters/ocp-templates/scripts
+./upload-templates.sh
+```
+
+Finally, the provisioning app should be updated. To do that, run `tailor update`
+in each `ocp-config` folder, and then trigger a build in Jenkins.
+
+Now that the general procedure has been completed, you need to apply all the
+update notes below which apply to your version change.
+
+### 0.1.0 to 1.0.0
+
+#### Update `xyz-cd` projects
+There is a new webhook proxy now, which proxies webhooks sent from BitBucket to
+Jenkins. As well as proxying, this service creates and deletes pipelines on the
+fly, allowing to have one pipeline per branch. To update:
+* Setup the image in the `cd` project by running `tailor update` in
+  `ods-core/jenkins/webhook-proxy/ocp-config`.
+* Build the image.
+* Setup the  webhook proxy next to each Jenkins instance. E.g., go to
+  `ods-project-quickstarters/ocp-templates/templates` and run
+  `oc process cd/cd-jenkins-webhook-proxy | oc create -f- -n xyz-cd`. Repeat for
+  each project.
+
+#### Update components
+For each component, follow the following steps:
+In `Jenkinsfile`:
+1. Set the shared library version to `1.0.x`.
+2. Replace `stageUpdateOpenshiftBuild` with `stageStartOpenshiftBuild`.
+3. Remove `stageCreateOpenshiftEnvironment` and `stageTriggerAllBuilds`.
+4. Adapt the build logic to match the latest state of the quickstarter
+   boilerplates.
+5. Remove `verbose: true` config (replace with `debug: true` if you want debug
+   output).
+6. Configure `branchToEnvironmentMapping`, see README.md. If you used
+   environment cloning, also apply the instructions for that.
+In `docker/Dockerfile`:
+Adapt the content to match the latest state of the quickstarter boilerplates.
+In BitBucket, remove the existing "Post Webhooks" and create a new "Webhook",
+pointing to the new webhook proxy. The URL has to be of the form
+`https://webhook-proxy-$PROJECT_ID-cd.$DOMAIN?trigger_secret=$SECRET`. As
+events, select "Repository Push" and "Pull request Merged + Declined".

--- a/doc/update-guide.md
+++ b/doc/update-guide.md
@@ -3,11 +3,6 @@
 Learn all about how to update your OpenDevStack repositories and the running
 installation of it.
 
-For the rest of this guide, it is assumed that you have completed the
-[Getting Started](https://github.com/opendevstack) guide. In the examples, we
-will use "ACME" as the organisation name, which you will need to replace where
-required.
-
 ## How to update your OpenDevStack repositories
 
 Updating repositories means that new refs from repositories under

--- a/doc/update-guide.md
+++ b/doc/update-guide.md
@@ -8,7 +8,7 @@ installation of it.
 Updating repositories means that new refs from repositories under
 `github.com/opendevstack` are pushed into the repositories in your BitBucket
 instance. Note that only updates to the `production` branch in BitBucket will
-have any effect on the OpenDevstack installation.
+have any effect on the OpenDevStack installation.
 
 First, you need a clone of each repository in BitBucket which should be updated
 on your local machine.
@@ -22,29 +22,28 @@ git remote add ods https://github.com/opendevstack/<REPO_NAME>.git
 
 Now you are ready to update the refs. It is recommended to update both the
 `master` branch and, unless you want to live off the bleeding edge, a release
-branch such as `1.0.x`. Both is shown below:
+branch such as `1.0.x`. Use the steps shown below:
 
 ```sh
 # Ensure you have the latest refs from ODS locally
 git fetch ods
 # Update master
 git checkout master
-git reset -hard ods/master
+git reset --hard ods/master
 git push origin master
 # Update 1.0.x
 git checkout 1.0.x
-git reset -hard ods/1.0.x
+git reset --hard ods/1.0.x
 git push origin 1.0.x
 ```
 
 So far, your OpenDevStack installation has not been affected yet because the
 `production` branch has not been updated yet. To do that, it is recommended to
-create a pull request on BitBucket from `master` into `production` This serves
+create a pull request on BitBucket from `1.0.x` into `production` This serves
 as a gate to control changes coming in, and spread knowledge about what has
 changed exactly.
 
-Now that changes are "live", you need update (parts of) the installation as
-described in the next section.
+Now that changes are "live", you need to update (parts of) the installation.
 
 
 ## How to update your OpenDevStack installation
@@ -69,18 +68,20 @@ Next, update Tailor to the version corresponding to your new OpenDevStack
 version.
 
 Then, update the configuration parameters (located in `ods-configuration`)
-according to what has changedd in the `ods-configuration-sample` repository.
+according to what has changed in the `ods-configuration-sample` repository.
 
 Once configuration is up-to-date, the OpenShift templates stored within
 OpenShift need to be updated:
 
 ```sh
-cd ods-project-quickstarters/ocp-templates/scripts
+# Within your local "ods-project-quickstarters" repository
+cd ocp-templates/scripts
 ./upload-templates.sh
 ```
 
 Finally, the provisioning app should be updated. To do that, run `tailor update`
-in each `ocp-config` folder, and then trigger a build in Jenkins.
+in each `ocp-config` folder, and then trigger a build in Jenkins to redeploy the
+service.
 
 Now that the general procedure has been completed, you need to apply all the
 update notes below which apply to your version change.


### PR DESCRIPTION
This is supposed to replace https://github.com/opendevstack/PMC/blob/b16d605d26a276fec8c216c1e4fb14501dc137e6/CONTRIBUTING.md and what was proposed in https://github.com/opendevstack/PMC/pull/9.

I think the previous CONTRIBUTING guide was (a) in the wrong repo, (b) it contained too much information for someone just trying to implement a change and (c) missed a few things that would be good to explain to newcomers.

By keeping update and development separate, we avoid a lot of complexity in the contributing section.