### PR TITLE
secure route checking moved to ods-contrib

### DIFF
--- a/docs/modules/administrator-guides/pages/update.adoc
+++ b/docs/modules/administrator-guides/pages/update.adoc
@@ -106,6 +106,9 @@ update notes below which apply to your version change.
 
 ==== Setup secure route checking
 
+This secure route checking code has been removed in version 2.1.x as this is an
+optional step. The code now is available at https://github.com/BIX-Digital/ods-contrib.
+
 Go to `ods-core/check-ocp-secure-routes/ocp-config` and run `tailor update` to setup a cron job that will check exposed routes once a day (see https://github.com/opendevstack/ods-core/pull/280).
 
 ==== Project specific CD users


### PR DESCRIPTION
Doc Update related to https://github.com/opendevstack/ods-core/pull/449

Is there a version 2.1.x? 