### PR TITLE
use proper release data for 3.0 and add planned dates for 3.1 and 4.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,9 @@ layout: bootstrap-default
           <li>June 2019 - release <a href="https://github.com/orgs/opendevstack/projects/4">1.1</a></li>
           <li>October 2019 - release <a href="https://github.com/orgs/opendevstack/projects/8">1.2</a></li>
           <li>December 2019 - release <a href="https://github.com/orgs/opendevstack/projects/6">2.0</a></li>
-          <li>May 2020 - release <a href="https://github.com/orgs/opendevstack/projects/9">3.0</a></li>
+          <li>August 2020 - release <a href="https://github.com/orgs/opendevstack/projects/9">3.0</a></li>
+          <li>Oktober 2020 - release <a href="https://github.com/orgs/opendevstack/projects/11">3.1</a></li>
+          <li>Dezember 2020 - release <a href="https://github.com/orgs/opendevstack/projects/10">4.0</a></li>
           <li>Following: Release of continuously advanced versions</li>
         </ul>
         If you are interested in OpenDevStack, as a user or contributor, please contact us.


### PR DESCRIPTION
This is the entrypoint to the project and its information.

If there's no intention to keep this up-to-date, it might make sense to drop the release info, although it shows that the project is active.

If it should be current, then I'd recommend adding an issue to the 4.x project NOW, so that the page is updated when released or build this info based on github actions :-)